### PR TITLE
Convert TeX to XML and then to HTML

### DIFF
--- a/bindings.sty.ltxml
+++ b/bindings.sty.ltxml
@@ -1,0 +1,7 @@
+package MyLuaLatexBindings;
+use LaTeXML::Package;
+DefConstructor('\begintt{}', '<verbatim>', mode=>'text');
+DefConstructor('\endtt', '</verbatim>', mode=>'text');
+
+# Ignore directlua macro (Replace with appropriate handling as needed)
+DefMacro('\directlua#1', '');

--- a/tex2md.py
+++ b/tex2md.py
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# File name without extension
+filename="oberon"
+
+# Step 1: Convert TeX to XML
+latexml --includestyles "$filename.tex" --preload=[bindings.sty.ltxml] --output="$filename.xml"
+
+# Step 2: Convert XML to HTML
+latexmlpost "$filename.xml" --format=html5 --destination="$filename.html"


### PR DESCRIPTION
Addresses: https://github.com/guidoism/tex-oberon/issues/1

This is an attempt to start conversion of `oberon.tex` to XML an then to HTML.

I don't have enough knowledge of TeX related tooling, so this PR is just to demonstrate my effort (in case it's helpful to others) and a possible follow-up.
The current attempt breaks at the first code example, the result can be viewed here:

https://html-oberon.surge.sh

Another approach might to be to use: https://github.com/phfaist/pylatexenc